### PR TITLE
Set default nfdi project id to 1

### DIFF
--- a/config/initializers/seek_configuration.rb
+++ b/config/initializers/seek_configuration.rb
@@ -264,7 +264,7 @@ def load_seek_config_defaults!
   #nfid4health
   Seek::Config.default :nfdi_studyhub_enabled, true
   Seek::Config.default :nfdi_other_studyhub_resource_id, nil
-  Seek::Config.default :nfdi_default_project_id, 2
+  Seek::Config.default :nfdi_default_project_id, 1
 
 
   load_seek_testing_defaults! if Rails.env.test?


### PR DESCRIPTION
Fresh seek instances throw an error because they don't have a project with id 2