### PR TITLE
exclude rejected assets from the requested_approval_assets list

### DIFF
--- a/app/controllers/studyhub_resources_controller.rb
+++ b/app/controllers/studyhub_resources_controller.rb
@@ -281,7 +281,7 @@ class StudyhubResourcesController < ApplicationController
       Rails.logger.info("The request is sent from API......")
       @rt = StudyhubResourceType.where(title: params[:studyhub_resource][:resource_json][:resource_classification][:resource_type]).first
       params[:studyhub_resource][:studyhub_resource_type_id] = @rt.id unless @rt.nil?
-
+      params[:studyhub_resource][:commit_button] = 'Submit'
     else
       Rails.logger.info("The request is sent from UI......")
 

--- a/app/models/resource_publish_log.rb
+++ b/app/models/resource_publish_log.rb
@@ -23,6 +23,7 @@ class ResourcePublishLog < ApplicationRecord
                                                                             WAITING_FOR_APPROVAL])
     requested_approval_assets = requested_approval_logs.collect(&:resource).compact
     requested_approval_assets.reject!(&:is_published?)
+    requested_approval_assets.reject!(&:is_rejected?)
     requested_approval_assets.select! { |asset| gatekeeper.is_asset_gatekeeper_of? asset }
     requested_approval_assets.uniq.sort_by{ |asset| asset.resource_publish_logs.last.created_at}.reverse!
 

--- a/app/serializers/studyhub_resource_serializer.rb
+++ b/app/serializers/studyhub_resource_serializer.rb
@@ -64,21 +64,21 @@ class StudyhubResourceSerializer < PCSSerializer
             end
           end
 
-          if key == 'study_data_sharing_plan'
+          if study_design.key?('study_data_sharing_plan') && (key == 'study_data_sharing_plan')
             unless study_design['study_data_sharing_plan'][attr].blank?
               study_design['study_data_sharing_plan'][attr] =
                 convert_id_to_label_for_multi_select_attribute(study_design['study_data_sharing_plan'][attr])
             end
           end
 
-          if object.is_non_interventional_study? && key == 'study_design_non_interventional'
+          if object.is_non_interventional_study? && key == 'study_design_non_interventional' && study_design.key?('study_design_non_interventional')
             unless study_design['study_design_non_interventional'][attr].blank?
               study_design['study_design_non_interventional'][attr] =
                 convert_id_to_label_for_multi_select_attribute(study_design['study_design_non_interventional'][attr])
             end
           end
 
-          if object.is_interventional_study? && key == 'study_masking'
+          if object.is_interventional_study? && key == 'study_masking' && study_design.key?('study_masking')
             unless study_design['study_design_interventional']['study_masking'][attr].blank?
               study_design['study_design_interventional']['study_masking'][attr]= convert_id_to_label_for_multi_select_attribute(study_design['study_design_interventional']['study_masking'][attr])
             end

--- a/app/serializers/studyhub_resource_serializer.rb
+++ b/app/serializers/studyhub_resource_serializer.rb
@@ -44,28 +44,38 @@ class StudyhubResourceSerializer < PCSSerializer
 
           study_design = object.resource_json['study_design']
 
-          study_design[attr] =
-            convert_id_to_label_for_multi_select_attribute(study_design[attr]) unless study_design[attr].blank?
+          unless study_design[attr].blank?
+            study_design[attr] =
+              convert_id_to_label_for_multi_select_attribute(study_design[attr])
+          end
 
 
-          if key == 'study_data_source'
-            study_design['study_data_source'][attr] =
-              convert_id_to_label_for_multi_select_attribute(study_design['study_data_source'][attr]) unless study_design['study_data_source'][attr].blank?
+          if key == 'study_data_source' && !study_design['study_data_source'].blank?
+            unless study_design['study_data_source'][attr].blank?
+              study_design['study_data_source'][attr] =
+                convert_id_to_label_for_multi_select_attribute(study_design['study_data_source'][attr])
+            end
           end
 
           if study_design.key?('study_eligibility_criteria') && (key == 'study_eligibility_criteria')
-            study_design['study_eligibility_criteria'][attr] =
-              convert_id_to_label_for_multi_select_attribute(study_design['study_eligibility_criteria'][attr]) unless study_design['study_eligibility_criteria'][attr].blank?
+            unless study_design['study_eligibility_criteria'][attr].blank?
+              study_design['study_eligibility_criteria'][attr] =
+                convert_id_to_label_for_multi_select_attribute(study_design['study_eligibility_criteria'][attr])
+            end
           end
 
           if key == 'study_data_sharing_plan'
-            study_design['study_data_sharing_plan'][attr] =
-              convert_id_to_label_for_multi_select_attribute(study_design['study_data_sharing_plan'][attr]) unless study_design['study_data_sharing_plan'][attr].blank?
+            unless study_design['study_data_sharing_plan'][attr].blank?
+              study_design['study_data_sharing_plan'][attr] =
+                convert_id_to_label_for_multi_select_attribute(study_design['study_data_sharing_plan'][attr])
+            end
           end
 
           if object.is_non_interventional_study? && key == 'study_design_non_interventional'
-            study_design['study_design_non_interventional'][attr] =
-              convert_id_to_label_for_multi_select_attribute(study_design['study_design_non_interventional'][attr]) unless study_design['study_design_non_interventional'][attr].blank?
+            unless study_design['study_design_non_interventional'][attr].blank?
+              study_design['study_design_non_interventional'][attr] =
+                convert_id_to_label_for_multi_select_attribute(study_design['study_design_non_interventional'][attr])
+            end
           end
 
           if object.is_interventional_study? && key == 'study_masking'
@@ -77,9 +87,6 @@ class StudyhubResourceSerializer < PCSSerializer
       end
     end
   end
-
-
-
 
 
   def convert_id_to_label_for_multi_select_attribute(array)

--- a/app/serializers/studyhub_resource_serializer.rb
+++ b/app/serializers/studyhub_resource_serializer.rb
@@ -53,7 +53,7 @@ class StudyhubResourceSerializer < PCSSerializer
               convert_id_to_label_for_multi_select_attribute(study_design['study_data_source'][attr]) unless study_design['study_data_source'][attr].blank?
           end
 
-          if key == 'study_eligibility_criteria'
+          if study_design.key?('study_eligibility_criteria') && (key == 'study_eligibility_criteria')
             study_design['study_eligibility_criteria'][attr] =
               convert_id_to_label_for_multi_select_attribute(study_design['study_eligibility_criteria'][attr]) unless study_design['study_eligibility_criteria'][attr].blank?
           end

--- a/lib/tasks/seek_dev_nfdi4health_data_migration_to_MDS_ v2_1.rake
+++ b/lib/tasks/seek_dev_nfdi4health_data_migration_to_MDS_ v2_1.rake
@@ -153,17 +153,6 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
       # 3.['provenance']
       new_json['provenance'] = {}
       new_json['provenance']['data_source'] = json['provenance']['data_source']
-      new_json['provenance']['verification_date'] = ''
-      new_json['provenance']['verification_date_user'] = ''
-      new_json['provenance']['resource_first_submitted_date'] = ''
-      new_json['provenance']['resource_first_submitted_user'] = ''
-      new_json['provenance']['resource_first_posted_date'] = ''
-      new_json['provenance']['resource_first_posted_user'] = ''
-      new_json['provenance']['last_update_submitted_date'] = ''
-      new_json['provenance']['last_update_submitted_user'] = ''
-      new_json['provenance']['last_update_posted_date'] = ''
-      new_json['provenance']['last_update_posted_user'] = ''
-      new_json['provenance']['resource_version'] = ''
 
       # 4. ['resource_titles']
       new_json['resource_titles'] = []
@@ -406,8 +395,10 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
         new_json['study_design']['study_data_source']['study_data_sources_biosamples'] = []
         new_json['study_design']['study_data_source']['study_data_sources_imaging'] = []
         new_json['study_design']['study_data_source']['study_data_sources_omics'] = []
-        new_json['study_design']['study_data_source']['study_data_source_description'] =
-          sd['study_data_source_description'] unless sd['study_data_source_description'].blank?
+        unless sd['study_data_source_description'].blank?
+          new_json['study_design']['study_data_source']['study_data_source_description'] =
+            sd['study_data_source_description']
+        end
 
         old_ds = sd['study_data_source'].map{|x| SampleControlledVocabTerm.find(x).label}
         study_data_sources_general = []
@@ -492,56 +483,50 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
         new_json['study_design']['study_obtained_sample_size'] = sd['study_obtained_sample_size'] unless sd['study_obtained_sample_size'].blank?
 
         #['study_design']['study_age_min_examined']
-        new_json['study_design']['study_age_min_examined'] = {}
-        new_json['study_design']['study_age_min_examined']['number'] = sd['study_age_min_examined']
-        #todo check if 'time_unit' is a new item in 2.1
-        new_json['study_design']['study_age_min_examined']['time_unit'] = ''
+
+        unless sd['study_age_min_examined'].blank?
+          new_json['study_design']['study_age_min_examined'] = {}
+          new_json['study_design']['study_age_min_examined']['number'] = sd['study_age_min_examined']
+          new_json['study_design']['study_age_min_examined']['time_unit'] = nil
+        end
+
 
         #['study_design']['study_age_max_examined']
-        new_json['study_design']['study_age_max_examined'] = {}
-        new_json['study_design']['study_age_max_examined']['number'] = sd['study_age_max_examined']
-        #todo check if 'time_unit' is a new item in 2.1
-        new_json['study_design']['study_age_max_examined']['time_unit'] = ''
+        unless sd['study_age_max_examined'].blank?
+          new_json['study_design']['study_age_max_examined'] = {}
+          new_json['study_design']['study_age_max_examined']['number'] = sd['study_age_max_examined']
+          new_json['study_design']['study_age_max_examined']['time_unit'] = nil
+        end
 
 
         # ['study_design']['study_hypothesis']
-        new_json['study_design']['study_hypothesis'] = sd['study_hypothesis']
+        new_json['study_design']['study_hypothesis'] = sd['study_hypothesis'] unless sd['study_hypothesis'].blank?
 
         #['study_design']['study_arms_groups']
-        new_json['study_design']['study_arms_groups'] = if (sr.is_interventional_study? && !sd['interventional_study_design']['interventional_study_design_arms'].blank?)
-                                                          sd['interventional_study_design']['interventional_study_design_arms']
-                                                        else
-                                                          []
-                                                        end
+        if (sr.is_interventional_study? && !sd['interventional_study_design']['interventional_study_design_arms'].blank?)
+          new_json['study_design']['study_arms_groups'] =  sd['interventional_study_design']['interventional_study_design_arms']
+        end
 
         #['study_design']['study_interventions']
-        new_json['study_design']['study_interventions'] = if (sr.is_interventional_study? && !sd['interventional_study_design']['interventional_study_design_interventions'].blank?)
-                                                            study_interventions = []
-                                                            sd['interventional_study_design']['interventional_study_design_interventions']&.each do |old|
-                                                              new = {}
-                                                              new['study_intervention_arms_groups_label'] = old['study_intervention_arm_group_label']
-                                                              new['study_intervention_name'] = old['study_intervention_name']
-                                                              new['study_intervention_type'] = old['study_intervention_type']
-                                                              new['study_intervention_description'] = old['study_intervention_description']
-                                                              study_interventions << new
-                                                            end
-                                                            study_interventions
-                                                          else
-                                                            []
-                                                          end
+        if (sr.is_interventional_study? && !sd['interventional_study_design']['interventional_study_design_interventions'].blank?)
+          study_interventions = []
+          sd['interventional_study_design']['interventional_study_design_interventions']&.each do |old|
+            new = {}
+            new['study_intervention_arms_groups_label'] = old['study_intervention_arm_group_label']
+            new['study_intervention_name'] = old['study_intervention_name']
+            new['study_intervention_type'] = old['study_intervention_type']
+            new['study_intervention_description'] = old['study_intervention_description']
+            study_interventions << new
+          end
+          new_json['study_design']['study_interventions'] = study_interventions
+        end
 
 
         #['study_design']['study_outcomes']
-        new_json['study_design']['study_outcomes'] = if !sd['study_outcomes'].blank?
-                                                       sd['study_outcomes']
-                                                      else
-                                                        []
-                                                      end
-
-
+        new_json['study_design']['study_outcomes'] = sd['study_outcomes'] unless sd['study_outcomes'].blank?
 
         #['study_design']['study_design_comment']
-        new_json['study_design']['study_design_comment'] = sd['study_design_comment']
+        new_json['study_design']['study_design_comment'] = sd['study_design_comment'] unless sd['study_design_comment'].blank?
 
 
 
@@ -549,59 +534,100 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
         new_json['study_design']['study_data_sharing_plan'] = {}
         new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_generally'] =
           sd['study_data_sharing_plan_generally'].chomp('.')
-        new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_description'] =
-          sd['study_data_sharing_plan_description']
-        new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_datashield'] = ''
-        new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_url'] =
-          sd['study_data_sharing_plan_url']
+        unless sd['study_data_sharing_plan_description'].blank?
+          new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_description'] =
+            sd['study_data_sharing_plan_description']
+        end
+        unless sd['study_data_sharing_plan_url'].blank?
+          new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_url'] =
+            sd['study_data_sharing_plan_url']
+        end
 
 
         if sd['study_data_sharing_plan_generally'] == 'Yes, there is a plan to make data available.'
-          new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_supporting_information'] =
-            sd['study_data_sharing_plan_supporting_information']
-          new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_time_frame'] =
-            sd['study_data_sharing_plan_time_frame']
-          new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_access_criteria'] =
-            sd['study_data_sharing_plan_access_criteria']
+          unless sd['study_data_sharing_plan_supporting_information'].blank?
+            new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_supporting_information'] =
+              sd['study_data_sharing_plan_supporting_information']
+          end
+          unless sd['study_data_sharing_plan_time_frame'].blank?
+            new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_time_frame'] =
+              sd['study_data_sharing_plan_time_frame']
+          end
+          unless sd['study_data_sharing_plan_access_criteria'].blank?
+            new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_access_criteria'] =
+              sd['study_data_sharing_plan_access_criteria']
+          end
         end
 
 
         #['study_design']['study_design_interventional']
         if sr.is_interventional_study?
+
           new_json['study_design']['study_design_interventional'] = {}
-          new_json['study_design']['study_design_interventional']['study_phase'] =
-            sd['interventional_study_design']['study_phase']
+
+          #['study_design']['study_design_interventional']['study_phase']
+          unless sd['interventional_study_design']['study_phase'].blank?
+            new_json['study_design']['study_design_interventional']['study_phase'] =
+              sd['interventional_study_design']['study_phase']
+          end
+
+          #['study_design']['study_design_interventional']['study_masking']
           new_json['study_design']['study_design_interventional']['study_masking'] = {}
-          #todo check if the mapping is ok
+
           new_json['study_design']['study_design_interventional']['study_masking']['study_masking_general'] =
-            sd['interventional_study_design']['study_masking']
+            sd['interventional_study_design']['study_masking'] unless sd['interventional_study_design']['study_masking'].blank?
+
           if sd['interventional_study_design']['study_masking']
             new_json['study_design']['study_design_interventional']['study_masking']['study_masking_roles'] =
               sd['interventional_study_design']['study_masking_roles']
           end
+
           if sd['interventional_study_design']['study_masking']
             new_json['study_design']['study_design_interventional']['study_masking']['study_masking_description'] =
               sd['interventional_study_design']['study_masking_description']
           end
-          new_json['study_design']['study_design_interventional']['study_allocation'] =
-            sd['interventional_study_design']['study_allocation']
-          new_json['study_design']['study_design_interventional']['study_off_label_use'] =
-            sd['interventional_study_design']['study_off_label_use']
+          new_json['study_design']['study_design_interventional'].delete('study_masking') if new_json['study_design']['study_design_interventional']['study_masking'].blank?
+
+
+          #['study_design']['study_design_interventional']['study_allocation']
+          unless sd['interventional_study_design']['study_allocation'].blank?
+            new_json['study_design']['study_design_interventional']['study_allocation'] =
+              sd['interventional_study_design']['study_allocation']
+          end
+
+          #['study_design']['study_design_interventional']['study_off_label_use']
+          unless sd['interventional_study_design']['study_off_label_use'].blank?
+            new_json['study_design']['study_design_interventional']['study_off_label_use'] =
+              sd['interventional_study_design']['study_off_label_use']
+          end
+
+          new_json['study_design'].delete('study_design_interventional') if new_json['study_design']['study_design_interventional'].blank?
         end
 
         #['study_design']['study_design_non_interventional']
         if sr.is_non_interventional_study?
           new_json['study_design']['study_design_non_interventional'] = {}
-          new_json['study_design']['study_design_non_interventional']['study_time_perspectives'] =
-            sd['non_interventional_study_design']['study_time_perspective']
-          new_json['study_design']['study_design_non_interventional']['study_target_followup_duration'] =
-            sd['non_interventional_study_design']['study_target_follow-up_duration']
-          new_json['study_design']['study_design_non_interventional']['study_biospecimen_retention'] =
-            sd['non_interventional_study_design']['study_biospecimen_retention']
-          new_json['study_design']['study_design_non_interventional']['study_biospecimen_description'] =
-            sd['non_interventional_study_design']['study_biospecomen_description']
+          unless sd['non_interventional_study_design']['study_time_perspective'].blank?
+            new_json['study_design']['study_design_non_interventional']['study_time_perspectives'] =
+              sd['non_interventional_study_design']['study_time_perspective']
+          end
+          unless sd['non_interventional_study_design']['study_target_follow-up_duration'].blank?
+            new_json['study_design']['study_design_non_interventional']['study_target_followup_duration'] =
+              sd['non_interventional_study_design']['study_target_follow-up_duration']
+          end
+          unless sd['non_interventional_study_design']['study_biospecimen_retention'].blank?
+            new_json['study_design']['study_design_non_interventional']['study_biospecimen_retention'] =
+              sd['non_interventional_study_design']['study_biospecimen_retention']
+          end
+          unless sd['non_interventional_study_design']['study_biospecomen_description'].blank?
+            new_json['study_design']['study_design_non_interventional']['study_biospecimen_description'] =
+              sd['non_interventional_study_design']['study_biospecomen_description']
+          end
         end
+        new_json['study_design'].delete('study_design_non_interventional') if new_json['study_design']['study_design_non_interventional'].blank?
+
       end
+
 
 
       # at the very end to print new_json and update the resource_json

--- a/lib/tasks/seek_dev_nfdi4health_data_migration_to_MDS_ v2_1.rake
+++ b/lib/tasks/seek_dev_nfdi4health_data_migration_to_MDS_ v2_1.rake
@@ -70,12 +70,16 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
           new_id = {}
           new_id['identifier'] = id['id_identifier']
           new_id['type'] = id['id_type']
-          new_id['date'] = id['id_date']
+          new_id['date'] = id['id_date'] unless id['id_date'].blank?
           new_id['relation_type'] = id['id_relation_type'].blank? ? '' : 'A ' + id['id_relation_type'] + ' B'
-          new_id['resource_type_general'] = id['id_resource_type_general']
+          new_id['resource_type_general'] = id['id_resource_type_general'] unless id['id_resource_type_general'].blank?
           new_json['ids'] << new_id
         end
       end
+      new_json.delete('ids_alternative') if new_json['ids_alternative'].blank?
+      new_json.delete('ids_nfdi4health') if new_json['ids_nfdi4health'].blank?
+      new_json.delete('ids') if new_json['ids'].blank?
+
 
 
       # 2.['roles']
@@ -84,8 +88,8 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
 
         new_role = {}
 
-        new_role['role_email'] = role['role_email']
-        new_role['role_phone'] = role['role_phone']
+        new_role['role_email'] = role['role_email'] unless role['role_email'].blank?
+        new_role['role_phone'] = role['role_phone'] unless role['role_phone'].blank?
 
 
         case role['role_name_type']
@@ -119,8 +123,8 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
         new_role['role_affiliations'] = []
         role_affiliations = {}
         role_affiliations['role_affiliation_name'] = role['role_affiliation_name']
-        role_affiliations['role_affiliation_address'] = role['role_affiliation_address']
-        role_affiliations['role_affiliation_web_page'] = role['role_affiliation_web_page']
+        role_affiliations['role_affiliation_address'] = role['role_affiliation_address'] unless role['role_affiliation_address'].blank?
+        role_affiliations['role_affiliation_web_page'] = role['role_affiliation_web_page'] unless role['role_affiliation_web_page'].blank?
         role_affiliations['role_affiliation_identifiers'] = []
 
         role['role_affiliation_identifiers'].each do |id|
@@ -129,8 +133,11 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
           new_id['scheme'] = id['role_affiliation_identifier_scheme']
           role_affiliations['role_affiliation_identifiers'] << new_id
         end
+        role_affiliations.delete('role_affiliation_identifiers') if role_affiliations['role_affiliation_identifiers'].blank?
 
         new_role['role_affiliations'] << role_affiliations
+
+        new_role.delete('role_affiliations') if new_role['role_affiliations'].blank?
 
         new_json['roles'] << new_role
       end

--- a/lib/tasks/seek_dev_nfdi4health_data_migration_to_MDS_ v2_1.rake
+++ b/lib/tasks/seek_dev_nfdi4health_data_migration_to_MDS_ v2_1.rake
@@ -96,7 +96,6 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
           new_role['role_name_organisational_group']['type'] = role['role_type'].chomp('person')
           new_role['role_name_organisational_group']['role_name_organisational_group_name'] =
             role['role_name_organisational']
-          new_role['role_name_organisational_group']['role_name_organisational_group_type_funding_id'] = ''
 
         when 'Personal'
           new_role['role_name_type'] = 'Personal'
@@ -106,6 +105,7 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
           new_role['role_name_personal']['role_name_personal_family_name'] = role['role_name_personal_family_name']
           new_role['role_name_personal']['role_name_personal_title'] = role['role_name_personal_title']
 
+
           new_role['role_name_personal']['role_name_identifiers'] = []
           role['role_name_identifiers'].each do |id|
             new_id = {}
@@ -113,7 +113,7 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
             new_id['scheme'] = id['role_name_identifier_scheme']
             new_role['role_name_personal']['role_name_identifiers'] << new_id
           end
-
+          new_role['role_name_personal'].delete('role_name_identifiers') if new_role['role_name_personal']['role_name_identifiers'].blank?
         end
 
         new_role['role_affiliations'] = []
@@ -160,22 +160,25 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
       end
 
       # 5. ['resource_acronyms']
-      new_json['resource_acronyms'] = []
-      json['resource_acronyms'].each do |acronym|
-        new_acronyms = {}
-        new_acronyms['text'] = acronym['acronym']
-        new_acronyms['language'] = acronym['acronym_language']
-        new_json['resource_acronyms'] << new_acronyms
+      unless json['resource_acronyms'].blank?
+        new_json['resource_acronyms'] = []
+        json['resource_acronyms'].each do |acronym|
+          new_acronyms = {}
+          new_acronyms['text'] = acronym['acronym']
+          new_acronyms['language'] = acronym['acronym_language']
+          new_json['resource_acronyms'] << new_acronyms
+        end
       end
 
-
       # 6. ['resource_languages']
-      new_json['resource_languages'] = json['resource_language']
-
+      unless json['resource_language'].blank?
+         new_json['resource_languages'] = json['resource_language']
+      end
 
       # 7. ['resource_web_page']
-      new_json['resource_web_page'] = json['resource_web_page']
-
+      unless json['resource_web_page'].blank?
+        new_json['resource_web_page'] = json['resource_web_page']
+      end
 
       # 8.  ['resource_description_english']
       new_json['resource_description_english'] = {}
@@ -201,12 +204,10 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
           new_desc['language'] = desc['description_language']
           non_english_descrs << new_desc
         end
-        if non_english_descrs.blank?
-          non_english_descrs[0] = {}
-          non_english_descrs[0]['text'] = ''
-          non_english_descrs[0]['language'] = ''
+        unless non_english_descrs.blank?
+          new_json['resource_descriptions_non_english'] = non_english_descrs
         end
-        new_json['resource_descriptions_non_english'] = non_english_descrs
+
       end
 
 
@@ -215,8 +216,9 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
       new_json['resource_classification']['resource_type'] = sr.studyhub_resource_type.title
 
       #11. ['resource_keywords']
-      new_json['resource_keywords'] = json['resource_keywords']
-
+      unless json['resource_keywords'].blank?
+        new_json['resource_keywords'] = json['resource_keywords']
+      end
 
       ###################non_study#####################
 
@@ -227,9 +229,12 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
 
         # 11. ['resource_non_study_details']
         new_json['resource_non_study_details'] = {}
-        new_json['resource_non_study_details']['resource_version'] = json['resource_version']
-        new_json['resource_non_study_details']['resource_format']  = json['resource_format']
+        new_json['resource_non_study_details']['resource_version'] = json['resource_version'] unless json['resource_version'].blank?
+        new_json['resource_non_study_details']['resource_format']  = json['resource_format'] unless json['resource_format'].blank?
+
+
         resource_use_rights = {}
+
         resource_use_rights['resource_use_rights_label'] = json['resource_use_rights_label']
 
         if ['CC BY 4.0 (Creative Commons Attribution 4.0 International)',
@@ -247,8 +252,12 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
             json['resource_use_rights_support_by_licencing']
         end
 
-        resource_use_rights['resource_use_rights_description'] = json['resource_use_rights_description']
+
+        resource_use_rights['resource_use_rights_description'] = json['resource_use_rights_description'] unless json['resource_use_rights_description'].blank?
         new_json['resource_non_study_details']['resource_use_rights'] = resource_use_rights
+
+        new_json.delete('resource_non_study_details') if new_json['resource_non_study_details'].blank?
+
       end
 
       # 12. ['study_design']

--- a/lib/tasks/seek_dev_nfdi4health_data_migration_to_MDS_ v2_1.rake
+++ b/lib/tasks/seek_dev_nfdi4health_data_migration_to_MDS_ v2_1.rake
@@ -6,30 +6,31 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
   task(update_sample_controlled_vocab_terms: :environment) do
 
     # add_new_values_to_study_data_source
-    scv= SampleControlledVocab.where(title: 'NFDI4Health Study Data Source').first
+    scv = SampleControlledVocab.where(title: 'NFDI4Health Study Data Source').first
     scv.sample_controlled_vocab_terms << SampleControlledVocabTerm.find_or_create_by(label: 'Biological samples')
     scv.sample_controlled_vocab_terms << SampleControlledVocabTerm.find_or_create_by(label: 'Imaging data')
     scv.sample_controlled_vocab_terms << SampleControlledVocabTerm.find_or_create_by(label: 'Omics technology')
 
     #update_allowed_values_of_relation_type
-    scv= SampleControlledVocab.where(title:  'NFDI4Health ID Relation Type').first
+    scv = SampleControlledVocab.where(title:  'NFDI4Health ID Relation Type').first
     scv.sample_controlled_vocab_terms.each do |term|
-      term.update_attributes label: 'A '+term.label+' B' unless term.label.start_with? 'A'
+      term.update_attributes label: 'A ' + term.label + ' B' unless term.label.start_with? 'A'
     end
 
     #update_allowed_values_of_study_data_sharing_plan_generally
-    scv= SampleControlledVocab.where(title:  'NFDI4Health Study Data Sharing Plan Generally').first
+    scv = SampleControlledVocab.where(title:  'NFDI4Health Study Data Sharing Plan Generally').first
     scv.sample_controlled_vocab_terms.each do |term|
       term.update_attributes label: term.label.chomp('.')
     end
 
     #rename_contact_person_to_contact
-    scv= SampleControlledVocab.where(title:  'NFDI4Health Role Type').first
+    scv = SampleControlledVocab.where(title:  'NFDI4Health Role Type').first
     scv.sample_controlled_vocab_terms.where(label: 'Contact person').first.update_attributes label: 'Contact'
 
     #remove_allowed_values_of_study_subject
     scv = SampleControlledVocab.where(title:  'NFDI4Health Study Subject').first
-    scv.sample_controlled_vocab_terms = scv.sample_controlled_vocab_terms.select {|term| ['Person', 'Animal', 'Other', 'Unknown'].include? term.label }
+    scv.sample_controlled_vocab_terms = scv.sample_controlled_vocab_terms.select {|term|
+ ['Person', 'Animal', 'Other', 'Unknown'].include? term.label }
 
     #update_allowed_values_of_study_biospecimen_retention
     scv = SampleControlledVocab.where(title:  'NFDI4Health Study Biospecimen Retention').first
@@ -63,14 +64,14 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
           nfdi_id = {}
           nfdi_id['identifier'] = id['id_identifier']
           nfdi_id['relation_type'] = id['id_relation_type']
-          nfdi_id['relation_type'] = id['id_relation_type'].blank? ? '' : 'A '+id['id_relation_type']+ ' B'
+          nfdi_id['relation_type'] = id['id_relation_type'].blank? ? '' : 'A ' + id['id_relation_type'] + ' B'
           new_json['ids_nfdi4health'] << nfdi_id
         else
           new_id = {}
           new_id['identifier'] = id['id_identifier']
           new_id['type'] = id['id_type']
           new_id['date'] = id['id_date']
-          new_id['relation_type'] = id['id_relation_type'].blank? ? '' : 'A '+id['id_relation_type']+ ' B'
+          new_id['relation_type'] = id['id_relation_type'].blank? ? '' : 'A ' + id['id_relation_type'] + ' B'
           new_id['resource_type_general'] = id['id_resource_type_general']
           new_json['ids'] << new_id
         end
@@ -92,8 +93,9 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
           new_role['role_name_type'] = 'Organisational'
 
           new_role['role_name_organisational_group'] = {}
-          new_role['role_name_organisational_group']['type'] = role['role_type'].chomp(' person')
-          new_role['role_name_organisational_group']['role_name_organisational_group_name'] = role['role_name_organisational']
+          new_role['role_name_organisational_group']['type'] = role['role_type'].chomp('person')
+          new_role['role_name_organisational_group']['role_name_organisational_group_name'] =
+            role['role_name_organisational']
           new_role['role_name_organisational_group']['role_name_organisational_group_type_funding_id'] = ''
 
         when 'Personal'
@@ -194,7 +196,7 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
         non_english_descrs = []
 
         unless desc['description_language'] == 'EN (English)'
-          new_desc ={}
+          new_desc = {}
           new_desc['text'] = desc['description']
           new_desc['language'] = desc['description_language']
           non_english_descrs << new_desc
@@ -235,14 +237,18 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
             'CC BY-SA 4.0 (Creative Commons Attribution Share Alike 4.0 International)',
             'CC BY-NC-SA 4.0 (Creative Commons Attribution Non Commercial Share Alike 4.0 International)'].include? json['resource_use_rights_label']
           resource_use_rights['resource_use_rights_confirmations'] = {}
-          resource_use_rights['resource_use_rights_confirmations']['resource_use_rights_authors_confirmation_1'] = json['resource_use_rights_authors_confirmation_1']
-          resource_use_rights['resource_use_rights_confirmations']['resource_use_rights_authors_confirmation_2'] = json['resource_use_rights_authors_confirmation_2']
-          resource_use_rights['resource_use_rights_confirmations']['resource_use_rights_authors_confirmation_3'] = json['resource_use_rights_authors_confirmation_3']
-          resource_use_rights['resource_use_rights_confirmations']['resource_use_rights_support_by_licencing'] = json['resource_use_rights_support_by_licencing']
+          resource_use_rights['resource_use_rights_confirmations']['resource_use_rights_authors_confirmation_1'] =
+            json['resource_use_rights_authors_confirmation_1']
+          resource_use_rights['resource_use_rights_confirmations']['resource_use_rights_authors_confirmation_2'] =
+            json['resource_use_rights_authors_confirmation_2']
+          resource_use_rights['resource_use_rights_confirmations']['resource_use_rights_authors_confirmation_3'] =
+            json['resource_use_rights_authors_confirmation_3']
+          resource_use_rights['resource_use_rights_confirmations']['resource_use_rights_support_by_licencing'] =
+            json['resource_use_rights_support_by_licencing']
         end
 
         resource_use_rights['resource_use_rights_description'] = json['resource_use_rights_description']
-        new_json['resource_non_study_details']['resource_use_rights']  = resource_use_rights
+        new_json['resource_non_study_details']['resource_use_rights'] = resource_use_rights
       end
 
       # 12. ['study_design']
@@ -250,7 +256,7 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
 
         sd = json['study_design']
 
-        new_json['study_design']={}
+        new_json['study_design'] = {}
 
         # ['study_design']['study_primary_design']
         new_json['study_design']['study_primary_design'] = sd['study_primary_design']
@@ -261,7 +267,7 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
         # ['study_design']['study_conditions']
         new_json['study_design']['study_conditions'] = []
         sd['study_conditions'].each do |con|
-          new_condition ={}
+          new_condition = {}
           new_condition['study_conditions_label'] = con['study_conditions']
           new_condition['study_conditions_classification'] = con['study_conditions_classification']
           new_condition['study_conditions_classification_code'] = con['study_conditions_classification_code']
@@ -270,9 +276,9 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
 
         # ['study_design']['study_groups_of_diseases']
         new_json['study_design']['study_groups_of_diseases'] = {}
-        new_json['study_design']['study_groups_of_diseases']['study_groups_of_diseases_generally']=['Unknown']
-        new_json['study_design']['study_groups_of_diseases']['study_groups_of_diseases_prevalent_outcomes']=''
-        new_json['study_design']['study_groups_of_diseases']['study_groups_of_diseases_incident_outcomes']=''
+        new_json['study_design']['study_groups_of_diseases']['study_groups_of_diseases_generally'] = ['Unknown']
+        new_json['study_design']['study_groups_of_diseases']['study_groups_of_diseases_prevalent_outcomes'] = ''
+        new_json['study_design']['study_groups_of_diseases']['study_groups_of_diseases_incident_outcomes'] = ''
 
         # ['study_design']['study_ethics_committee_approval']
         new_json['study_design']['study_ethics_committee_approval'] = if sd['study_ethics_commitee_approval'].blank?
@@ -372,18 +378,20 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
                                                     end
 
         #['study_design']['study_sampling']
-        new_json['study_design']['study_sampling']={}
+        new_json['study_design']['study_sampling'] = {}
 
         if sd['study_sampling'].start_with?('Probability')
           new_json['study_design']['study_sampling']['study_sampling_method'] = 'Probability'
           unless sd['study_sampling'] == 'Probability'
-            new_json['study_design']['study_sampling']['study_sampling_method_probability'] = sd['study_sampling'].partition("(").last.partition(")").first
+            new_json['study_design']['study_sampling']['study_sampling_method_probability'] =
+              sd['study_sampling'].partition("(").last.partition(")").first
           end
 
         elsif sd['study_sampling'].start_with?('Non-probability')
           new_json['study_design']['study_sampling']['study_sampling_method'] = 'Non-probability'
           unless sd['study_sampling'] == 'Non-probability'
-            new_json['study_design']['study_sampling']['study_sampling_method_non_probability'] = sd['study_sampling'].partition("(").last.partition(")").first
+            new_json['study_design']['study_sampling']['study_sampling_method_non_probability'] =
+              sd['study_sampling'].partition("(").last.partition(")").first
           end
 
         else
@@ -398,14 +406,16 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
         #['study_design']['study_data_source']
         biological_samples = ['Blood', 'Buccal cells', 'Cord blood', 'DNA', 'Faeces', 'Hair', 'Immortalized cell lines',
                               'Isolated pathogen', 'Nail', 'Plasma', 'RNA', 'Saliva', 'Serum', 'Tissue (frozen)', 'Tissue (FFPE)', 'Urine', 'Other biological samples']
-        imaging_data = ['Imaging data (ultrasound)','Imaging data (MRI)','Imaging data (MRI, radiography)','Imaging data (CT)','Other imaging data']
+        imaging_data = ['Imaging data (ultrasound)','Imaging data (MRI)','Imaging data (MRI, radiography)',
+'Imaging data (CT)','Other imaging data']
         proteomics = ['Genomics','Metabolomics','Transcriptomics','Proteomics','Other omics technology']
         new_json['study_design']['study_data_source'] = {}
         new_json['study_design']['study_data_source']['study_data_sources_general'] = []
         new_json['study_design']['study_data_source']['study_data_sources_biosamples'] = []
         new_json['study_design']['study_data_source']['study_data_sources_imaging'] = []
         new_json['study_design']['study_data_source']['study_data_sources_omics'] = []
-        new_json['study_design']['study_data_source']['study_data_source_description'] = sd['study_data_source_description']
+        new_json['study_design']['study_data_source']['study_data_source_description'] =
+          sd['study_data_source_description']
 
         old_ds = sd['study_data_source'].map{|x| SampleControlledVocabTerm.find(x).label}
         study_data_sources_general = []
@@ -424,7 +434,7 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
             study_data_sources_general << ds_id
           end
         end
-        new_json['study_design']['study_data_source']['study_data_sources_general']= study_data_sources_general.uniq
+        new_json['study_design']['study_data_source']['study_data_sources_general'] = study_data_sources_general.uniq
 
         #['study_design']['study_primary_purpose']
         new_json['study_design']['study_primary_purpose'] = if sr.is_interventional_study?
@@ -434,24 +444,46 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
                                                             end
 
         #['study_design']['study_eligibility_criteria']
-        new_json['study_design']['study_eligibility_criteria']={}
+        new_json['study_design']['study_eligibility_criteria'] = {}
         study_eligibility_age_min = {}
         study_eligibility_age_max = {}
 
-        new_json['study_design']['study_eligibility_criteria']['study_eligibility_genders'] = sd['study_eligibility_gender']
-        new_json['study_design']['study_eligibility_criteria']['study_eligibility_inclusion_criteria'] = sd['study_eligibility_inclusion_criteria']
-        new_json['study_design']['study_eligibility_criteria']['study_eligibility_exclusion_criteria'] = sd['study_eligibility_exclusion_criteria']
+        unless sd['study_eligibility_gender'].blank?
+          new_json['study_design']['study_eligibility_criteria']['study_eligibility_genders'] =
+            sd['study_eligibility_gender']
+        end
 
-        study_eligibility_age_min['number'] = sd['study_eligibility_age_min']
-        #todo check if 'time_unit' is a new item in 2.1
-        study_eligibility_age_min['time_unit']=''
+        unless sd['study_eligibility_inclusion_criteria'].blank?
+          new_json['study_design']['study_eligibility_criteria']['study_eligibility_inclusion_criteria'] =
+            sd['study_eligibility_inclusion_criteria']
+        end
 
-        study_eligibility_age_max['number']= sd['study_eligibility_age_max']
-        #todo check if 'time_unit' is a new item in 2.1
-        study_eligibility_age_max['time_unit']=''
+        unless sd['study_eligibility_exclusion_criteria'].blank?
+          new_json['study_design']['study_eligibility_criteria']['study_eligibility_exclusion_criteria'] =
+            sd['study_eligibility_exclusion_criteria']
+        end
 
-        new_json['study_design']['study_eligibility_criteria']['study_eligibility_age_min'] = study_eligibility_age_min
-        new_json['study_design']['study_eligibility_criteria']['study_eligibility_age_max'] = study_eligibility_age_max
+        unless sd['study_eligibility_age_min'].blank?
+          study_eligibility_age_min['number'] = sd['study_eligibility_age_min']
+          study_eligibility_age_min['time_unit'] = nil
+        end
+
+        unless sd['study_eligibility_age_max'].blank?
+          study_eligibility_age_max['number'] = sd['study_eligibility_age_max']
+          study_eligibility_age_max['time_unit'] = nil
+        end
+
+        unless study_eligibility_age_min.blank?
+          new_json['study_design']['study_eligibility_criteria']['study_eligibility_age_min'] =
+            study_eligibility_age_min
+        end
+
+        unless study_eligibility_age_max.blank?
+          new_json['study_design']['study_eligibility_criteria']['study_eligibility_age_max'] =
+            study_eligibility_age_max
+        end
+
+        new_json['study_design'].delete('study_eligibility_criteria') if new_json['study_design']['study_eligibility_criteria'].blank?
 
         #['study_design']['study_population']
         new_json['study_design']['study_population'] = sd['study_population']
@@ -470,7 +502,7 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
         new_json['study_design']['study_age_min_examined']['time_unit'] = ''
 
         #['study_design']['study_age_max_examined']
-        new_json['study_design']['study_age_max_examined']= {}
+        new_json['study_design']['study_age_max_examined'] = {}
         new_json['study_design']['study_age_max_examined']['number'] = sd['study_age_max_examined']
         #todo check if 'time_unit' is a new item in 2.1
         new_json['study_design']['study_age_max_examined']['time_unit'] = ''
@@ -504,8 +536,8 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
 
 
         #['study_design']['study_outcomes']
-        new_json['study_design']['study_outcomes']  = if !sd['study_outcomes'].blank?
-                                                        sd['study_outcomes']
+        new_json['study_design']['study_outcomes'] = if !sd['study_outcomes'].blank?
+                                                       sd['study_outcomes']
                                                       else
                                                         []
                                                       end
@@ -519,39 +551,59 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
 
         #['study_design']['study_data_sharing_plan']
         new_json['study_design']['study_data_sharing_plan'] = {}
-        new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_generally'] = sd['study_data_sharing_plan_generally'].chomp('.')
-        new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_description'] = sd['study_data_sharing_plan_description']
+        new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_generally'] =
+          sd['study_data_sharing_plan_generally'].chomp('.')
+        new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_description'] =
+          sd['study_data_sharing_plan_description']
         new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_datashield'] = ''
-        new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_url'] = sd['study_data_sharing_plan_url']
+        new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_url'] =
+          sd['study_data_sharing_plan_url']
 
 
         if sd['study_data_sharing_plan_generally'] == 'Yes, there is a plan to make data available.'
-          new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_supporting_information'] = sd['study_data_sharing_plan_supporting_information']
-          new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_time_frame'] = sd['study_data_sharing_plan_time_frame']
-          new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_access_criteria'] = sd['study_data_sharing_plan_access_criteria']
+          new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_supporting_information'] =
+            sd['study_data_sharing_plan_supporting_information']
+          new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_time_frame'] =
+            sd['study_data_sharing_plan_time_frame']
+          new_json['study_design']['study_data_sharing_plan']['study_data_sharing_plan_access_criteria'] =
+            sd['study_data_sharing_plan_access_criteria']
         end
 
 
         #['study_design']['study_design_interventional']
         if sr.is_interventional_study?
           new_json['study_design']['study_design_interventional'] = {}
-          new_json['study_design']['study_design_interventional']['study_phase'] = sd['interventional_study_design']['study_phase']
+          new_json['study_design']['study_design_interventional']['study_phase'] =
+            sd['interventional_study_design']['study_phase']
           new_json['study_design']['study_design_interventional']['study_masking'] = {}
           #todo check if the mapping is ok
-          new_json['study_design']['study_design_interventional']['study_masking']['study_masking_general'] = sd['interventional_study_design']['study_masking']
-          new_json['study_design']['study_design_interventional']['study_masking']['study_masking_roles'] = sd['interventional_study_design']['study_masking_roles'] if sd['interventional_study_design']['study_masking']
-          new_json['study_design']['study_design_interventional']['study_masking']['study_masking_description'] = sd['interventional_study_design']['study_masking_description'] if sd['interventional_study_design']['study_masking']
-          new_json['study_design']['study_design_interventional']['study_allocation'] = sd['interventional_study_design']['study_allocation']
-          new_json['study_design']['study_design_interventional']['study_off_label_use'] = sd['interventional_study_design']['study_off_label_use']
+          new_json['study_design']['study_design_interventional']['study_masking']['study_masking_general'] =
+            sd['interventional_study_design']['study_masking']
+          if sd['interventional_study_design']['study_masking']
+            new_json['study_design']['study_design_interventional']['study_masking']['study_masking_roles'] =
+              sd['interventional_study_design']['study_masking_roles']
+          end
+          if sd['interventional_study_design']['study_masking']
+            new_json['study_design']['study_design_interventional']['study_masking']['study_masking_description'] =
+              sd['interventional_study_design']['study_masking_description']
+          end
+          new_json['study_design']['study_design_interventional']['study_allocation'] =
+            sd['interventional_study_design']['study_allocation']
+          new_json['study_design']['study_design_interventional']['study_off_label_use'] =
+            sd['interventional_study_design']['study_off_label_use']
         end
 
         #['study_design']['study_design_non_interventional']
         if sr.is_non_interventional_study?
           new_json['study_design']['study_design_non_interventional'] = {}
-          new_json['study_design']['study_design_non_interventional']['study_time_perspectives'] = sd['non_interventional_study_design']['study_time_perspective']
-          new_json['study_design']['study_design_non_interventional']['study_target_followup_duration'] = sd['non_interventional_study_design']['study_target_follow-up_duration']
-          new_json['study_design']['study_design_non_interventional']['study_biospecimen_retention'] = sd['non_interventional_study_design']['study_biospecimen_retention']
-          new_json['study_design']['study_design_non_interventional']['study_biospecimen_description'] = sd['non_interventional_study_design']['study_biospecomen_description']
+          new_json['study_design']['study_design_non_interventional']['study_time_perspectives'] =
+            sd['non_interventional_study_design']['study_time_perspective']
+          new_json['study_design']['study_design_non_interventional']['study_target_followup_duration'] =
+            sd['non_interventional_study_design']['study_target_follow-up_duration']
+          new_json['study_design']['study_design_non_interventional']['study_biospecimen_retention'] =
+            sd['non_interventional_study_design']['study_biospecimen_retention']
+          new_json['study_design']['study_design_non_interventional']['study_biospecimen_description'] =
+            sd['non_interventional_study_design']['study_biospecomen_description']
         end
       end
 

--- a/lib/tasks/seek_dev_nfdi4health_data_migration_to_MDS_ v2_1.rake
+++ b/lib/tasks/seek_dev_nfdi4health_data_migration_to_MDS_ v2_1.rake
@@ -117,14 +117,20 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
             new_id['scheme'] = id['role_name_identifier_scheme']
             new_role['role_name_personal']['role_name_identifiers'] << new_id
           end
-          new_role['role_name_personal'].delete('role_name_identifiers') if new_role['role_name_personal']['role_name_identifiers'].blank?
+          if new_role['role_name_personal']['role_name_identifiers'].blank?
+            new_role['role_name_personal'].delete('role_name_identifiers')
+          end
         end
 
         new_role['role_affiliations'] = []
         role_affiliations = {}
         role_affiliations['role_affiliation_name'] = role['role_affiliation_name']
-        role_affiliations['role_affiliation_address'] = role['role_affiliation_address'] unless role['role_affiliation_address'].blank?
-        role_affiliations['role_affiliation_web_page'] = role['role_affiliation_web_page'] unless role['role_affiliation_web_page'].blank?
+        unless role['role_affiliation_address'].blank?
+          role_affiliations['role_affiliation_address'] = role['role_affiliation_address']
+        end
+        unless role['role_affiliation_web_page'].blank?
+          role_affiliations['role_affiliation_web_page'] = role['role_affiliation_web_page']
+        end
         role_affiliations['role_affiliation_identifiers'] = []
 
         role['role_affiliation_identifiers'].each do |id|
@@ -133,7 +139,9 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
           new_id['scheme'] = id['role_affiliation_identifier_scheme']
           role_affiliations['role_affiliation_identifiers'] << new_id
         end
-        role_affiliations.delete('role_affiliation_identifiers') if role_affiliations['role_affiliation_identifiers'].blank?
+        if role_affiliations['role_affiliation_identifiers'].blank?
+          role_affiliations.delete('role_affiliation_identifiers')
+        end
 
         new_role['role_affiliations'] << role_affiliations
 
@@ -178,14 +186,10 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
       end
 
       # 6. ['resource_languages']
-      unless json['resource_language'].blank?
-         new_json['resource_languages'] = json['resource_language']
-      end
+      new_json['resource_languages'] = json['resource_language'] unless json['resource_language'].blank?
 
       # 7. ['resource_web_page']
-      unless json['resource_web_page'].blank?
-        new_json['resource_web_page'] = json['resource_web_page']
-      end
+      new_json['resource_web_page'] = json['resource_web_page'] unless json['resource_web_page'].blank?
 
       # 8.  ['resource_description_english']
       new_json['resource_description_english'] = {}
@@ -211,9 +215,7 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
           new_desc['language'] = desc['description_language']
           non_english_descrs << new_desc
         end
-        unless non_english_descrs.blank?
-          new_json['resource_descriptions_non_english'] = non_english_descrs
-        end
+        new_json['resource_descriptions_non_english'] = non_english_descrs unless non_english_descrs.blank?
 
       end
 
@@ -223,9 +225,7 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
       new_json['resource_classification']['resource_type'] = sr.studyhub_resource_type.title
 
       #11. ['resource_keywords']
-      unless json['resource_keywords'].blank?
-        new_json['resource_keywords'] = json['resource_keywords']
-      end
+      new_json['resource_keywords'] = json['resource_keywords'] unless json['resource_keywords'].blank?
 
       ###################non_study#####################
 
@@ -236,8 +236,12 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
 
         # 11. ['resource_non_study_details']
         new_json['resource_non_study_details'] = {}
-        new_json['resource_non_study_details']['resource_version'] = json['resource_version'] unless json['resource_version'].blank?
-        new_json['resource_non_study_details']['resource_format']  = json['resource_format'] unless json['resource_format'].blank?
+        unless json['resource_version'].blank?
+          new_json['resource_non_study_details']['resource_version'] = json['resource_version']
+        end
+        unless json['resource_format'].blank?
+          new_json['resource_non_study_details']['resource_format']  = json['resource_format']
+        end
 
 
         resource_use_rights = {}
@@ -260,7 +264,9 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
         end
 
 
-        resource_use_rights['resource_use_rights_description'] = json['resource_use_rights_description'] unless json['resource_use_rights_description'].blank?
+        unless json['resource_use_rights_description'].blank?
+          resource_use_rights['resource_use_rights_description'] = json['resource_use_rights_description']
+        end
         new_json['resource_non_study_details']['resource_use_rights'] = resource_use_rights
 
         new_json.delete('resource_non_study_details') if new_json['resource_non_study_details'].blank?
@@ -289,63 +295,52 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
           new_condition['study_conditions_classification_code'] = con['study_conditions_classification_code']
           new_json['study_design']['study_conditions'] << new_condition
         end
+        new_json['study_design'].delete('study_conditions') if new_json['study_design']['study_conditions'].blank?
 
         # ['study_design']['study_groups_of_diseases']
         new_json['study_design']['study_groups_of_diseases'] = {}
         new_json['study_design']['study_groups_of_diseases']['study_groups_of_diseases_generally'] = ['Unknown']
-        new_json['study_design']['study_groups_of_diseases']['study_groups_of_diseases_prevalent_outcomes'] = ''
-        new_json['study_design']['study_groups_of_diseases']['study_groups_of_diseases_incident_outcomes'] = ''
+
 
         # ['study_design']['study_ethics_committee_approval']
-        new_json['study_design']['study_ethics_committee_approval'] = if sd['study_ethics_commitee_approval'].blank?
-                                                                        ''
-                                                                      else
-                                                                        sd['study_ethics_commitee_approval']
-                                                                      end
+        unless sd['study_ethics_commitee_approval'].blank?
+          new_json['study_design']['study_ethics_committee_approval'] = sd['study_ethics_commitee_approval']
+        end
 
 
         #todo ['study_design']['study_status'], https://github.com/nfdi4health/metadataschema/issues/206
-        new_json['study_design']['study_status'] = sd['study_status']
+        new_json['study_design']['study_status'] = sd['study_status'] unless sd['study_status'].blank?
 
         if sr.is_interventional_study?
           if (sd['study_status'].start_with? 'Ongoing') || (sd['study_status'].start_with? 'At')
-            new_json['study_design']['study_status_when_intervention'] = sd['study_status_when_intervention']
+            new_json['study_design']['study_status_when_intervention'] = sd['study_status_when_intervention'] unless sd['study_status_when_intervention'].blank?
           end
         end
 
 
 
         if (sd['study_status'].start_with? 'Suspended') || (sd['study_status'].start_with? 'Terminated')
-          new_json['study_design']['study_status_halted_stage'] = sd['study_status_halted_stage']
-          new_json['study_design']['study_status_halted_reason'] = sd['study_status_halted_reason']
+          new_json['study_design']['study_status_halted_stage'] = sd['study_status_halted_stage'] unless sd['study_status_halted_stage'].blank?
+          new_json['study_design']['study_status_halted_reason'] = sd['study_status_halted_reason'] unless sd['study_status_halted_reason'].blank?
         end
 
-        new_json['study_design']['study_status_enrolling_by_invitation'] = sd['study_status_enrolling_by_invitation']
+        new_json['study_design']['study_status_enrolling_by_invitation'] = sd['study_status_enrolling_by_invitation'] unless sd['study_status_enrolling_by_invitation'].blank?
 
 
 
         # ['study_design']['study_recruitment_status_register']
-        new_json['study_design']['study_recruitment_status_register'] = if sd['study_recruitment_status_register'].blank?
-                                                                          ''
-                                                                        else
-                                                                          sd['study_recruitment_status_register']
-                                                                        end
+        unless sd['study_recruitment_status_register'].blank?
+          new_json['study_design']['study_recruitment_status_register'] = sd['study_recruitment_status_register']
+        end
 
 
         # ['study_design']['study_start_date']
-        new_json['study_design']['study_start_date'] = if sd['study_start_date'].blank?
-                                                         ''
-                                                       else
-                                                         sd['study_start_date']
-                                                       end
+        new_json['study_design']['study_start_date'] = sd['study_start_date'] unless sd['study_start_date'].blank?
+
 
 
         # ['study_design']['study_end_date']
-        new_json['study_design']['study_end_date'] = if sd['study_end_date'].blank?
-                                                       ''
-                                                     else
-                                                       sd['study_end_date']
-                                                     end
+        new_json['study_design']['study_end_date'] = sd['study_end_date'] unless sd['study_end_date'].blank?
 
 
         # ['study_design']['study_countries']
@@ -357,30 +352,14 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
 
 
         # ['study_design']['study_region']
-        new_json['study_design']['study_region'] = if sd['study_region'].blank?
-                                                     ''
-                                                   else
-                                                     sd['study_region']
-                                                   end
-
+        new_json['study_design']['study_region'] = sd['study_region'] unless sd['study_region'].blank?
 
 
         # ['study_design']['study_centers']
-        new_json['study_design']['study_centers'] = if sd['study_centers'].blank?
-                                                      ''
-                                                    else
-                                                      sd['study_centers']
-                                                    end
-
+        new_json['study_design']['study_centers'] = sd['study_centers'] unless sd['study_centers'].blank?
 
         # ['study_design']['study_centers_number']
-        new_json['study_design']['study_centers_number'] = if sd['study_centers_number'].blank?
-                                                             nil
-                                                           else
-                                                             sd['study_centers_number']
-                                                           end
-
-
+        new_json['study_design']['study_centers_number'] = sd['study_centers_number'] unless sd['study_centers_number'].blank?
 
         # ['study_design']['study_subject']
         new_json['study_design']['study_subject'] = if sd['study_subject'].blank?
@@ -411,13 +390,10 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
           end
 
         else
-          new_json['study_design']['study_sampling']['study_sampling_method'] = if sd['study_sampling'].blank?
-                                                                                  ''
-                                                                                else
-                                                                                  sd['study_sampling']
-                                                                                end
+          new_json['study_design']['study_sampling']['study_sampling_method'] =sd['study_sampling'] unless sd['study_sampling'].blank?
         end
 
+        new_json['study_design'].delete('study_sampling') if new_json['study_design']['study_sampling'].blank?
 
         #['study_design']['study_data_source']
         biological_samples = ['Blood', 'Buccal cells', 'Cord blood', 'DNA', 'Faeces', 'Hair', 'Immortalized cell lines',
@@ -431,7 +407,7 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
         new_json['study_design']['study_data_source']['study_data_sources_imaging'] = []
         new_json['study_design']['study_data_source']['study_data_sources_omics'] = []
         new_json['study_design']['study_data_source']['study_data_source_description'] =
-          sd['study_data_source_description']
+          sd['study_data_source_description'] unless sd['study_data_source_description'].blank?
 
         old_ds = sd['study_data_source'].map{|x| SampleControlledVocabTerm.find(x).label}
         study_data_sources_general = []
@@ -450,14 +426,16 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
             study_data_sources_general << ds_id
           end
         end
-        new_json['study_design']['study_data_source']['study_data_sources_general'] = study_data_sources_general.uniq
+
+        new_json['study_design']['study_data_source']['study_data_sources_general'] = study_data_sources_general.uniq unless study_data_sources_general.uniq.blank?
+        new_json['study_design']['study_data_source'].delete('study_data_sources_general') if new_json['study_design']['study_data_source']['study_data_sources_general'].blank?
+        new_json['study_design']['study_data_source'].delete('study_data_sources_biosamples') if new_json['study_design']['study_data_source']['study_data_sources_biosamples'].blank?
+        new_json['study_design']['study_data_source'].delete('study_data_sources_imaging') if new_json['study_design']['study_data_source']['study_data_sources_imaging'].blank?
+        new_json['study_design']['study_data_source'].delete('study_data_sources_omics') if new_json['study_design']['study_data_source']['study_data_sources_omics'].blank?
+        new_json['study_design'].delete('study_data_source') if new_json['study_design']['study_data_source'].blank?
 
         #['study_design']['study_primary_purpose']
-        new_json['study_design']['study_primary_purpose'] = if sr.is_interventional_study?
-                                                              sd['interventional_study_design']['study_primary_purpose']
-                                                            else
-                                                              ''
-                                                            end
+        new_json['study_design']['study_primary_purpose'] = sd['interventional_study_design']['study_primary_purpose'] if sr.is_interventional_study? && !sd['interventional_study_design']['study_primary_purpose'].blank?
 
         #['study_design']['study_eligibility_criteria']
         new_json['study_design']['study_eligibility_criteria'] = {}
@@ -499,17 +477,19 @@ namespace :seek_dev_nfdi4health_update_to_MDS_v2_1 do
             study_eligibility_age_max
         end
 
-        new_json['study_design'].delete('study_eligibility_criteria') if new_json['study_design']['study_eligibility_criteria'].blank?
+        if new_json['study_design']['study_eligibility_criteria'].blank?
+          new_json['study_design'].delete('study_eligibility_criteria')
+        end
 
         #['study_design']['study_population']
-        new_json['study_design']['study_population'] = sd['study_population']
+        new_json['study_design']['study_population'] = sd['study_population'] unless sd['study_population'].blank?
 
         #['study_design']['study_target_sample_size']
-        new_json['study_design']['study_target_sample_size'] = sd['study_target_sample_size']
+        new_json['study_design']['study_target_sample_size'] = sd['study_target_sample_size'] unless sd['study_target_sample_size'].blank?
 
 
         #['study_design']['study_obtained_sample_size']
-        new_json['study_design']['study_obtained_sample_size'] = sd['study_obtained_sample_size']
+        new_json['study_design']['study_obtained_sample_size'] = sd['study_obtained_sample_size'] unless sd['study_obtained_sample_size'].blank?
 
         #['study_design']['study_age_min_examined']
         new_json['study_design']['study_age_min_examined'] = {}


### PR DESCRIPTION
When a resource is rejected by the gatekeeper, it should be excluded from the requested_approval_assets list.  
It needs to be revised and published again.  
In the web mask, the **publish** button should be disabled until the resource is updated. 